### PR TITLE
Added code to add escape sequence to the page uri, else the maven build fails as the page uri has illegal escape sequence of "\"

### DIFF
--- a/src/main/java/com/tastymonster/automation/codegen/ParseVelocity.java
+++ b/src/main/java/com/tastymonster/automation/codegen/ParseVelocity.java
@@ -253,7 +253,7 @@ public class ParseVelocity implements IPresentationParser {
 			//Strip off the src path, and get the full path/filename for this, relative to the site root
 			//TODO - this should come from IPresentationParser.getTemplatePath()
 			String filePath = file.getPath().replace( "src/main/webapp/templates/", "" );
-			this.setPageURI( filePath );
+			this.setPageURI( StringEscapeUtils.escapeJava(filePath ));
 			this.setPageName( file.getName().replace( ".vm", "" ) );
 		} catch ( IOException e ) {
 			e.printStackTrace();


### PR DESCRIPTION
I also do find that mvn -P does not work for the first time. You need to do a mvn clean install first, which also fails and then only the mvn -P command works.