### PR TITLE
Added code to add escape sequence to the page uri, else the maven build fails as the page uri has illegal escape sequence of "\"

### DIFF
--- a/src/main/java/com/tastymonster/automation/codegen/ParseVelocity.java
+++ b/src/main/java/com/tastymonster/automation/codegen/ParseVelocity.java
@@ -17,6 +17,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.StringEscapeUtils; 
 
 import com.tastymonster.automation.element.base.ButtonWebElement;
 import com.tastymonster.automation.element.base.DivWebElement;

--- a/src/main/java/com/tastymonster/automation/codegen/ParseVelocity.java
+++ b/src/main/java/com/tastymonster/automation/codegen/ParseVelocity.java
@@ -253,7 +253,7 @@ public class ParseVelocity implements IPresentationParser {
 			//Strip off the src path, and get the full path/filename for this, relative to the site root
 			//TODO - this should come from IPresentationParser.getTemplatePath()
 			String filePath = file.getPath().replace( "src/main/webapp/templates/", "" );
-			this.setPageURI( filePath );
+			this.setPageURI( StringEscapeUtils.escapeJava(filePath ));
 			this.setPageName( file.getName().replace( ".vm", "" ) );
 		} catch ( IOException e ) {
 			e.printStackTrace();


### PR DESCRIPTION
I also found that the mvn -P does not work on the first attempt. You need to do a mvn clean install first which will also fail. But then if you do a mvn -P the build will be a success
